### PR TITLE
ShellyProEM + TotalActEnergy/TotalActEnergyRet

### DIFF
--- a/ShellyProEM/module.php
+++ b/ShellyProEM/module.php
@@ -20,41 +20,23 @@ class ShellyProEM extends ShellyModule
         ['bAprtPower', 'Phase B apparent Power', VARIABLETYPE_FLOAT, '~Watt', [], '', false, true, false],
         ['bPF', 'Phase B Power Factor', VARIABLETYPE_FLOAT, '', [], '', false, true, false],
 
-        /*emdata
         ['aTotalActEnergy', 'Phase A total active Energy', VARIABLETYPE_FLOAT, '~Electricity', [], '', false, true, false],
         ['aTotalActRetEnergy', 'Phase A total active returned Energy', VARIABLETYPE_FLOAT, '~Electricity', [], '', false, true, false],
         ['bTotalActEnergy', 'Phase B total active Energy', VARIABLETYPE_FLOAT, '~Electricity', [], '', false, true, false],
         ['bTotalActRetEnergy', 'Phase B total active returned Energy', VARIABLETYPE_FLOAT, '~Electricity', [], '', false, true, false],
-        ['cTotalActEnergy', 'Phase C total active Energy', VARIABLETYPE_FLOAT, '~Electricity', [], '', false, true, false],
-        ['cTotalActRetEnergy', 'Phase C total active returned Energy', VARIABLETYPE_FLOAT, '~Electricity', [], '', false, true, false],
-        ['totalActEnergy', 'Total active Energy', VARIABLETYPE_FLOAT, '~Electricity', [], '', false, true, false],
-        ['totalActRetEnergy', 'Total active returned Energy', VARIABLETYPE_FLOAT, '~Electricity', [], '', false, true, false],
-         */
+
         ['Reachable', 'Reachable', VARIABLETYPE_BOOLEAN, 'Shelly.Reachable', '', '', false, true, false]
     ];
 
     public function Create()
     {
         parent::Create();
-
-        /*Netting
-        $this->RegisterPropertyFloat('TotalActiveEnergyOffset', 0);
-        $this->RegisterPropertyFloat('TotalActRetEnergyOffset', 0);
-        $this->RegisterPropertyBoolean('Netting', false);
-         */
     }
 
     public function ApplyChanges()
     {
         //Never delete this line!
         parent::ApplyChanges();
-
-        /*Netting
-        $this->MaintainVariable('CurrentReturned', $this->Translate('Current Returned'), 2, '~Watt', 0, $this->ReadPropertyBoolean('Netting'));
-        $this->MaintainVariable('CurrentImport', $this->Translate('Current Import'), 2, '~Watt', 0, $this->ReadPropertyBoolean('Netting'));
-        $this->MaintainVariable('Import', $this->Translate('Import'), 2, '~Electricity', 0, $this->ReadPropertyBoolean('Netting'));
-        $this->MaintainVariable('Returned', $this->Translate('Returned'), 2, '~Electricity', 0, $this->ReadPropertyBoolean('Netting'));
-         */
     }
 
     public function RequestAction($Ident, $Value)
@@ -108,23 +90,19 @@ class ShellyProEM extends ShellyModule
                             $this->SetValue('bAprtPower', $Payload['aprt_power']);
                             $this->SetValue('bPF', $Payload['pf']);
                         }
-                        /*Netting
-                            if ($this->ReadPropertyBoolean('Netting')) {
-                                $this->Netting();
-                            }
-                            if (array_key_exists('emdata:0', $Payload['params'])) {
-                            $emData = $Payload['params']['emdata:0'];
-                            $this->SetValue('aTotalActEnergy', floatval($emData['a_total_act_energy']) / 1000);
-                            $this->SetValue('aTotalActRetEnergy', floatval($emData['a_total_act_ret_energy']) / 1000);
-                            $this->SetValue('bTotalActEnergy', floatval($emData['b_total_act_energy']) / 1000);
-                            $this->SetValue('bTotalActRetEnergy', floatval($emData['b_total_act_ret_energy']) / 1000);
-                            $this->SetValue('cTotalActEnergy', floatval($emData['c_total_act_energy']) / 1000);
-                            $this->SetValue('cTotalActRetEnergy', floatval($emData['c_total_act_ret_energy']) / 1000);
+					}
+				}
 
-                            $this->SetValue('totalActEnergy', (floatval($emData['total_act']) / 1000) + $this->ReadPropertyFloat('TotalActiveEnergyOffset'));
-                            $this->SetValue('totalActRetEnergy', (floatval($emData['total_act_ret']) / 1000) + $this->ReadPropertyFloat('TotalActRetEnergyOffset'));
+                if (fnmatch('*/status/em1data:*', $Buffer['Topic'])) {
+                    if (array_key_exists('id', $Payload)) {
+                        if ($Payload['id'] == 0) {
+                            $this->SetValue('aTotalActEnergy', $Payload['total_act_energy']);
+                            $this->SetValue('aTotalActRetEnergy', $Payload['total_act_ret_energy']);
                         }
-                         */
+                        if ($Payload['id'] == 1) {
+                            $this->SetValue('bTotalActEnergy', $Payload['total_act_energy']);
+                            $this->SetValue('bTotalActRetEnergy', $Payload['total_act_ret_energy']);
+                        }
                     }
                 }
             }
@@ -142,39 +120,7 @@ class ShellyProEM extends ShellyModule
 
         $this->sendMQTT($Topic, json_encode($Payload));
     }
-    /*Netting
-        private function Netting()
-        {
-            $Leistung = $this->GetValue('totalActPower');
 
-            $varZwischenSpericherEinspeisung = IPS_GetVariable($this->GetIDForIdent('CurrentReturned'));
-            $varZwischenSpericherBezug = IPS_GetVariable($this->GetIDForIdent('CurrentImport'));
-
-            $ZwischenSpericherEinspeisung = $this->GetValue('CurrentReturned');
-            $ZwischenSpericherBezug = $this->GetValue('CurrentImport');
-
-            if ($ZwischenSpericherEinspeisung > 0) {
-                $zeit = ($varZwischenSpericherEinspeisung['VariableChanged'] - time()) / 3600;
-                $kwh = (abs($ZwischenSpericherEinspeisung) * abs($zeit)) / 1000;
-                SetValue($this->GetIDForIdent('Returned'), GetValue($this->GetIDForIdent('Returned')) + $kwh);
-            }
-
-            if ($ZwischenSpericherBezug > 0) {
-                $zeit = ($varZwischenSpericherBezug['VariableChanged'] - time()) / 3600;
-                $kwh = ($ZwischenSpericherBezug * abs($zeit)) / 1000;
-                SetValue($this->GetIDForIdent('Import'), GetValue($this->GetIDForIdent('Import')) + $kwh);
-            }
-
-            if ($Leistung < 0) {
-                SetValue($this->GetIDForIdent('CurrentReturned'), abs($Leistung));
-                SetValue($this->GetIDForIdent('CurrentImport'), 0);
-            }
-            if ($Leistung > 0) {
-                SetValue($this->GetIDForIdent('CurrentImport'), abs($Leistung));
-                SetValue($this->GetIDForIdent('CurrentReturned'), 0);
-            }
-        }
-     */
     private function SwitchMode(int $switch, bool $value)
     {
         $Topic = $this->ReadPropertyString('MQTTTopic') . '/rpc';


### PR DESCRIPTION
Ich habe noch einen Shelly ProEM-50 in Betrieb genommen (ich nutze das, um zwei separate Verbraucher zu überwachen).

Bisher fehlte im Modul die Übernahme der Energie-Daten - Verbrauch und Einspeisung für Phase A und B getrennt. Saldierte Werte gibt es hier nicht vom Shelly; macht m.E. auch keinen Sinn selbst zu saldieren.

Ist nun drin.